### PR TITLE
fix: resolve "Page Not Found" error when clicking on Store and logo

### DIFF
--- a/ecommerce/store/templates/store/main.html
+++ b/ecommerce/store/templates/store/main.html
@@ -14,7 +14,7 @@
 <body>
 
 	<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="{url 'store'}">EDB</a>
+        <a class="navbar-brand" href="{% url 'store' %}">EDB</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -22,7 +22,7 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav mr-auto">
             <li class="nav-item active">
-              <a class="nav-link" href="{url 'store'}">Store <span class="sr-only">(current)</span></a>
+              <a class="nav-link" href="{% url 'store' %}">Store <span class="sr-only">(current)</span></a>
             </li>
           </ul>
 


### PR DESCRIPTION
Resolved a "Page Not Found" error caused when navigating to the Store page or clicking on the logo. Updated the `main.html` template to ensure correct routing and template rendering.